### PR TITLE
Ensure API requests fallback to PHP-FPM in Nginx config

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -50,8 +50,8 @@ server {
             return 204;
         }
 
-        # For API requests, always go to PHP-FPM
-        try_files @php_api;
+        # For API requests, first check for existing files then fallback to PHP-FPM
+        try_files $uri $uri/ @php_api;
     }
 
     # PHP-FPM handler for Laravel - robust configuration


### PR DESCRIPTION
## Summary
- Fix Nginx `try_files` directive for `/api/` location so existing files are served before falling back to PHP-FPM

## Testing
- `./docker/test-deployment.sh`
- ⚠️ `docker build -t availly .` (docker not installed)


------
https://chatgpt.com/codex/tasks/task_e_68aefd5b2884832b8280e9990167a087