### PR TITLE
Use document root for API fastcgi path

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -58,7 +58,7 @@ server {
     location @php_api {
         fastcgi_pass 127.0.0.1:9000;
         fastcgi_index index.php;
-        fastcgi_param SCRIPT_FILENAME /usr/share/nginx/html/api/public/index.php;
+        fastcgi_param SCRIPT_FILENAME $document_root/api/public/index.php;
         
         # Include standard FastCGI parameters
         include fastcgi_params;


### PR DESCRIPTION
## Summary
- reference PHP API entry point using `$document_root` in nginx template

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aefdb0d5cc832bb690a4205862b1d6